### PR TITLE
PERF: Minimize cost of freeing regions

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -41,7 +41,7 @@ let flags_with_sanitize =
     (* There is a known leak tracked here:
        https://github.com/kkos/oniguruma/issues/31 
        TODO: Investigate upgrading to bring back ASAN for this lib *)
-    | Linux -> flags @ ccopt("-fsanitize=address")
+    (*| Linux -> flags @ ccopt("-fsanitize=address")*)
     | _ -> flags
 ;;
 

--- a/config/discover.ml
+++ b/config/discover.ml
@@ -41,7 +41,7 @@ let flags_with_sanitize =
     (* There is a known leak tracked here:
        https://github.com/kkos/oniguruma/issues/31 
        TODO: Investigate upgrading to bring back ASAN for this lib *)
-    (* | Linux -> flags @ ccopt("-fsanitize=address") *)
+    | Linux -> flags @ ccopt("-fsanitize=address")
     | _ -> flags
 ;;
 

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -127,10 +127,10 @@ CAMLprim value reonig_search(value vStr, value vPos, value vRegExp) {
 
       Store_field(ret, i, v);
     };
-//    onig_region_free(p->region, 0);
+    onig_region_free(p->region, 0);
   } else {
     ret = Atom(0);
-//    onig_region_free(p->region, 0);
+    onig_region_free(p->region, 0);
   }
 
   CAMLreturn(ret);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -127,10 +127,8 @@ CAMLprim value reonig_search(value vStr, value vPos, value vRegExp) {
 
       Store_field(ret, i, v);
     };
-//    onig_region_free(p->region, 0);
   } else {
     ret = Atom(0);
-    //onig_region_free(p->region, 0);
   }
 
   CAMLreturn(ret);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -127,10 +127,10 @@ CAMLprim value reonig_search(value vStr, value vPos, value vRegExp) {
 
       Store_field(ret, i, v);
     };
-    onig_region_free(p->region, 0);
+//    onig_region_free(p->region, 0);
   } else {
     ret = Atom(0);
-    onig_region_free(p->region, 0);
+    //onig_region_free(p->region, 0);
   }
 
   CAMLreturn(ret);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -127,10 +127,10 @@ CAMLprim value reonig_search(value vStr, value vPos, value vRegExp) {
 
       Store_field(ret, i, v);
     };
-    onig_region_free(p->region, 0);
+//    onig_region_free(p->region, 0);
   } else {
     ret = Atom(0);
-    onig_region_free(p->region, 0);
+//    onig_region_free(p->region, 0);
   }
 
   CAMLreturn(ret);

--- a/test/OnigRegExpTest.re
+++ b/test/OnigRegExpTest.re
@@ -127,7 +127,6 @@ describe("OnigRegExp", ({describe, _}) => {
       };
     });
     test("capture group test - multiple runs", ({expect, _}) => {
-
       let r = OnigRegExp.create("(@selector\\()(.*?)(\\))");
       switch (r) {
       | Error(_) => expect.string("Fail").toEqual("")
@@ -140,7 +139,7 @@ describe("OnigRegExp", ({describe, _}) => {
           expect.string(Match.getText(result[1])).toEqual("@selector(");
           expect.string(Match.getText(result[3])).toEqual(")");
           incr(idx);
-        }
+        };
       };
     });
   });

--- a/test/OnigRegExpTest.re
+++ b/test/OnigRegExpTest.re
@@ -126,5 +126,22 @@ describe("OnigRegExp", ({describe, _}) => {
         expect.string(Match.getText(result[3])).toEqual(")");
       };
     });
+    test("capture group test - multiple runs", ({expect, _}) => {
+
+      let r = OnigRegExp.create("(@selector\\()(.*?)(\\))");
+      switch (r) {
+      | Error(_) => expect.string("Fail").toEqual("")
+      | Ok(regex) =>
+        // Run regexp with match group multiple times, verify we aren't leaking OnigRegions
+        let idx = ref(0);
+        while (idx^ < 5) {
+          let result =
+            OnigRegExp.search("@selector(windowWillClose:)", 0, regex);
+          expect.string(Match.getText(result[1])).toEqual("@selector(");
+          expect.string(Match.getText(result[3])).toEqual(")");
+          incr(idx);
+        }
+      };
+    });
   });
 });


### PR DESCRIPTION
When profiling `reason-textmate`, there were two major bottlenecks:
- Running the `onig_search` method. I'm not sure there is much we can optimize here, aside from reducing the frequency we call it.
- Freeing / newing the `onig_region`. This change minimizes the work we do by building on the change to cache the `OnigRegion`. It turns out, that we don't need to call `onig_region_free` explicitly if we're reusing it for the same regex - this can save us a significant amount of time.

The main concern was that it would leak memory, but this didn't seem to be the case testing with ASAN.